### PR TITLE
Test: backend specification on operations test

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 
+if [ $1 == "help" ] || [ -z $1 ]
+then
+    echo "A backend needs to be selected to test."
+    echo "Available options are SIMD_SSE and SIMPLE_CPU."
+    exit
+fi
+
 # Execute the operations test
 echo "- Operation correctness tests"
-sh test/operations.sh
+sh test/operations.sh $1
 echo ""
 
 # Execute vector size missmatch error test

--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $1 == "help" ] || [ -z $1 ]
+if [ $1 = "help" ] || [ -z $1 ]
 then
     echo "A backend needs to be selected to test."
     echo "Available options are SIMD_SSE and SIMPLE_CPU."

--- a/test/operations.sh
+++ b/test/operations.sh
@@ -1,13 +1,18 @@
 #!/bin/sh
 
+if [ $1 == "help" ] || [ -z $1 ]
+then
+    echo "The script does not test anything by itself, thebackend to be tested needs to be specified"
+    echo "Available options are SIMD_SSE and SIMPLE_CPU"
+    exit
+else
+    echo "Testing $1"
+fi
 
 COMPILATION_FLAGS="-msse4.1 -O2 -m64 -std=c++17"
 INCLUDE_FLAGS="-Isrc"
 
-echo "Simple CPU backend:"
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU test/src/operations.cc -o bin/operations
-./bin/operations
+rm -f bin/operations
 
-echo "SSE backend:"
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMD_SSE test/src/operations.cc -o bin/operations
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_$1 test/src/operations.cc -o bin/operations
 ./bin/operations

--- a/test/operations.sh
+++ b/test/operations.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $1 == "help" ] || [ -z $1 ]
+if [ $1 = "help" ] || [ -z $1 ]
 then
     echo "The script does not test anything by itself, thebackend to be tested needs to be specified"
     echo "Available options are SIMD_SSE and SIMPLE_CPU"

--- a/test/operations.sh
+++ b/test/operations.sh
@@ -2,7 +2,7 @@
 
 if [ $1 = "help" ] || [ -z $1 ]
 then
-    echo "The script does not test anything by itself, thebackend to be tested needs to be specified"
+    echo "A backend needs to be selected to test."
     echo "Available options are SIMD_SSE and SIMPLE_CPU"
     exit
 else


### PR DESCRIPTION
Right now as SSE is supported on almost all the CPUs testing it along with the simple backend gave no issues. But with the introduction of ARM SIMD or AVX512 not all CPUs support it. So when testing, the selected backend should be passed to test only that, and not all the implemented ones. As commented on issue #22.

This PR implements a command line argument for the operations.sh script (and execute_tests.sh in consecuence) to select the backend. If no backend is selected or `help` is passed all the available backends are listed to help the user.