### PR TITLE
Tests: AVX2 tested always.

### DIFF
--- a/test/operations.sh
+++ b/test/operations.sh
@@ -16,7 +16,3 @@ rm -f bin/operations
 
 g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_$1 test/src/operations.cc -o bin/operations
 ./bin/operations
-
-echo "AVX2 backend:"
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMD_AVX2 -mavx2 test/src/operations.cc -o bin/operations
-./bin/operations


### PR DESCRIPTION
Fixes bug #27. AVX2 test were hardcoded. Removing the hardcoded bit fixed the issue.