### PR TITLE
Enhancement: proper compile time errors

### DIFF
--- a/src/backends/simple/matrix_ops.hh
+++ b/src/backends/simple/matrix_ops.hh
@@ -35,12 +35,15 @@ bool operator!=(const matf<lnrow, lncol>& left, const matf<rnrow, rncol>& right)
  * Returns the addition of two matrices. If sizes don't match a compile time error is 
  * thrown.
  */
-template<size_t nrow, size_t ncol>
-matf<nrow, ncol> operator+(const matf<nrow, ncol>& left, const matf<nrow, ncol>& right) {
-    matf<nrow, ncol> result;
+template<size_t lnrow, size_t lncol, size_t rnrow, size_t rncol>
+matf<lnrow, lncol> operator+(const matf<lnrow, lncol>& left, const matf<rnrow, rncol>& right) {
+    static_assert(lnrow == rnrow && lncol == rncol,
+                  "Matrix sizes are not equal");
 
-    for(int i = 0; i < nrow; i++) {
-        for(int j = 0; j < ncol; j++) {
+    matf<lnrow, lncol> result;
+
+    for(int i = 0; i < lnrow; i++) {
+        for(int j = 0; j < lncol; j++) {
             result(i, j) = left(i, j) + right(i, j);
         }
     }
@@ -52,12 +55,15 @@ matf<nrow, ncol> operator+(const matf<nrow, ncol>& left, const matf<nrow, ncol>&
  * Returns the substraction of two matrices. If sizes don't match a compile time error is 
  * thrown.
  */
-template<size_t nrow, size_t ncol>
-matf<nrow, ncol> operator-(const matf<nrow, ncol>& left, const matf<nrow, ncol>& right) {
-    matf<nrow, ncol> result;
+template<size_t lnrow, size_t lncol, size_t rnrow, size_t rncol>
+matf<lnrow, lncol> operator-(const matf<lnrow, lncol>& left, const matf<rnrow, rncol>& right) {
+    static_assert(lnrow == rnrow && lncol == rncol,
+                  "Matrix sizes are not equal");
 
-    for(int i = 0; i < nrow; i++) {
-        for(int j = 0; j < ncol; j++) {
+    matf<lnrow, lncol> result;
+
+    for(int i = 0; i < lnrow; i++) {
+        for(int j = 0; j < lncol; j++) {
             result(i, j) = left(i, j) - right(i, j);
         }
     }
@@ -86,9 +92,12 @@ matf<nrow, ncol> operator*(float scalar, const matf<nrow, ncol>& right) {
  * operand does not equal to the number of rows of the right operand a compile time error
  * is thrown.
  */
-template<size_t lnrow, size_t lncol, size_t rncol>
+template<size_t lnrow, size_t lncol, size_t rnrow, size_t rncol>
 matf<lnrow, rncol> operator*(const matf<lnrow, lncol>& left, 
-                             const matf<lncol, rncol>& right) {
+                             const matf<rnrow, rncol>& right) {
+    static_assert(rnrow == lncol, 
+                  "Left's number of columns does not equal to right's number or rows");
+
     matf<lnrow, rncol> result;
 
     for(int i = 0; i < lnrow; i++) {

--- a/src/backends/simple/matrix_vector_ops.hh
+++ b/src/backends/simple/matrix_vector_ops.hh
@@ -5,8 +5,11 @@
  * If the vector's element count doesn't match matrix's number of columns a compile time 
  * error is thrown.
  */
-template<size_t nrow, size_t ncol>
-vecf<nrow> operator*(const matf<nrow, ncol>& mat, const vecf<ncol>& vec) {
+template<size_t nrow, size_t ncol, size_t vlen>
+vecf<nrow> operator*(const matf<nrow, ncol>& mat, const vecf<vlen>& vec) {
+    static_assert(ncol == vlen,
+                  "Vector length is not equal to the number of columns of the matrix");
+
     vecf<nrow> result;
     for(int i = 0; i < nrow; i++) {
         float sum = 0.0f;
@@ -25,8 +28,11 @@ vecf<nrow> operator*(const matf<nrow, ncol>& mat, const vecf<ncol>& vec) {
  * If the vector's element count doesn't match matrix's number of columns a compile time
  * error is thrown.
  */
-template<size_t nrow, size_t ncol>
-vecf<ncol> operator*(const vecf<ncol>& vec, const matf<nrow, ncol>& mat) {
+template<size_t nrow, size_t ncol, size_t vlen>
+vecf<ncol> operator*(const vecf<vlen>& vec, const matf<nrow, ncol>& mat) {
+    static_assert(vlen == ncol,
+                  "Vector length is not equal to the number of columns of the matrix");
+
     vecf<ncol> result;
     for(int i = 0; i < ncol; i++) {
         float sum = 0.0f;

--- a/src/backends/simple/vector_ops.hh
+++ b/src/backends/simple/vector_ops.hh
@@ -25,10 +25,13 @@ float length(const vecf<size>& vec) {
 /*
  * Returns dot product of two vectors.
  */
-template<size_t size>
-float dot(const vecf<size>& left, const vecf<size>& right) {
+template<size_t size1, size_t size2>
+float dot(const vecf<size1>& left, const vecf<size2>& right) {
+    static_assert(size1 == size2,
+                  "Vector sizes dont match");
+
     float sum = 0.0;
-    for(int i = 0; i < size; i++) {
+    for(int i = 0; i < size1; i++) {
         sum += right.data[i] * left.data[i];
     }
 
@@ -39,10 +42,13 @@ float dot(const vecf<size>& left, const vecf<size>& right) {
  * Performs the addition between two vectors of equal size. If the sizes of the vectors don't
  * match a compilation error is thrown.
  */
-template<size_t size>
-vecf<size> operator+(const vecf<size>& left, const vecf<size>& right) {
-    vecf<size> result;
-    for(int i = 0; i < size; i++)
+template<size_t size1, size_t size2>
+vecf<size1> operator+(const vecf<size1>& left, const vecf<size2>& right) {
+    static_assert(size1 == size2,
+                  "Vector sizes dont match");
+
+    vecf<size1> result;
+    for(int i = 0; i < size1; i++)
         result.data[i] = left.data[i] + right.data[i];
 
     return result;
@@ -52,10 +58,13 @@ vecf<size> operator+(const vecf<size>& left, const vecf<size>& right) {
  * Performs the substraction between two vectors of equal size. If the sizes of the vectors 
  * don't match a compilation error is thrown.
  */
-template<size_t size>
-vecf<size> operator-(const vecf<size>& left, const vecf<size>& right) {
-    vecf<size> result;
-    for(int i = 0; i < size; i++)
+template<size_t size1, size_t size2>
+vecf<size1> operator-(const vecf<size1>& left, const vecf<size2>& right) {
+    static_assert(size1 == size2,
+                  "Vector sizes dont match");
+
+    vecf<size1> result;
+    for(int i = 0; i < size1; i++)
         result.data[i] = left.data[i] - right.data[i];
 
     return result;
@@ -91,10 +100,14 @@ vecf<size> operator*(float scalar, const vecf<size>& right) {
  * Compares the passed vectors. True is returned if both vectors are equal and false is returned
  * if the vectors are not equal.
  */
-template<size_t size>
-bool operator==(const vecf<size>& left, const vecf<size>& right) {
+template<size_t size1, size_t size2>
+bool operator==(const vecf<size1>& left, const vecf<size2>& right) {
+    // TODO: check if a compile time error or a compile time error should be thrown
+    if constexpr(size1 != size2)
+        return false;
+
     bool is_equal;
-    for(int i = 0; i < size; i++) {
+    for(int i = 0; i < size1; i++) {
         if(left.data[i] != right.data[i]) 
             return false;
     }
@@ -106,7 +119,7 @@ bool operator==(const vecf<size>& left, const vecf<size>& right) {
  * Compares the passed vectors. False is returned if both vectors are equal and true is returned
  * if the vectors are not equal.
  */
-template<size_t size>
-bool operator!=(const vecf<size>& left, const vecf<size>& right) {
+template<size_t size1, size_t size2>
+bool operator!=(const vecf<size1>& left, const vecf<size2>& right) {
     return !(left == right);
 }

--- a/test/matrix_size_missmatch.sh
+++ b/test/matrix_size_missmatch.sh
@@ -4,8 +4,11 @@ COMPILATION_FLAGS="-msse4.1 -O2 -m64 -std=c++17"
 INCLUDE_FLAGS="-Isrc"
 
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_ADD test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch 2> /dev/null || echo "Addition missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_ADD test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch
+echo ""
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_SUB test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch 2> /dev/null || echo "Substraction missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_SUB test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch
+echo ""
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_MUL test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch 2> /dev/null || echo "Multiplication missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_MUL test/src/matrix_size_missmatch.cc -o bin/matrix_size_missmatch
+echo ""

--- a/test/vector_size_missmatch.sh
+++ b/test/vector_size_missmatch.sh
@@ -3,8 +3,8 @@
 COMPILATION_FLAGS="-msse4.1 -O2 -m64 -std=c++17"
 INCLUDE_FLAGS="-Isrc"
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_ADD test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch 2> /dev/null || echo "Addition missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_ADD test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_SUB test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch 2> /dev/null || echo "Substraction missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_SUB test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch
 
-g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_DOT test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch 2> /dev/null || echo "Dot product missmatch... OK"
+g++ $COMPILATION_FLAGS $INCLUDE_FLAGS -DLIBLINALG_BACKEND_SIMPLE_CPU -DMISSMATCH_DOT test/src/vector_size_missmatch.cc -o bin/vector_size_missmatch


### PR DESCRIPTION
Using the `static_assert` compile time checking custom messages can be sent. Using that, still, lots of template error stuff is thrown. 

If there was a way to just print the line in which the error is thrown and the custom message, that would be much nicer than the current error stack.

This issue tries to solve the issue #26 .