### PR TITLE
SSE+AVX2: Fixed addition bug

### DIFF
--- a/src/backends/avx2/vector_ops.hh
+++ b/src/backends/avx2/vector_ops.hh
@@ -93,7 +93,7 @@ vecf<size> operator+(const vecf<size>& left, const vecf<size>& right) {
     // Process in elements using AVX2 instructions
     for(int i = 0; i < parallel_iterations; i += LIBLINALG_PARALLEL_FLOATS) {
         __m256 left_elem = _mm256_load_ps(left.data + i);
-        __m256 right_elem = _mm256_load_ps(left.data + i);
+        __m256 right_elem = _mm256_load_ps(right.data + i);
         __m256 res_elem = _mm256_add_ps(left_elem, right_elem);
         _mm256_store_ps(result.data + i, res_elem);
     }

--- a/src/backends/sse/vector_ops.hh
+++ b/src/backends/sse/vector_ops.hh
@@ -98,7 +98,7 @@ vecf<size> operator+(const vecf<size>& left, const vecf<size>& right) {
     // Process in elements using SSE2 instructions
     for(int i = 0; i < parallel_iterations; i += 4) {
         __m128 left_elem = _mm_load_ps(left.data + i);
-        __m128 right_elem = _mm_load_ps(left.data + i);
+        __m128 right_elem = _mm_load_ps(right.data + i);
         __m128 res_elem = _mm_add_ps(left_elem, right_elem);
         _mm_store_ps(result.data + i, res_elem);
     }


### PR DESCRIPTION
This PR makes reference to the bug shown on issue #34.

Really easy fix as the addition was done by `left + left` instead of `left + right` when using AVX2 and SSE instructions. Copy paste error probably.