### PR TITLE
Tests: `if` errors fixed

### DIFF
--- a/execute_tests.sh
+++ b/execute_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $1 = "help" ] || [ -z $1 ]
+if [ $1="help" ] || [ -z $1 ]
 then
     echo "A backend needs to be selected to test."
     echo "Available options are SIMD_SSE and SIMPLE_CPU."

--- a/test/operations.sh
+++ b/test/operations.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ $1 = "help" ] || [ -z $1 ]
+if [ $1="help" ] || [ -z $1 ]
 then
     echo "A backend needs to be selected to test."
     echo "Available options are SIMD_SSE and SIMPLE_CPU"


### PR DESCRIPTION
When no arguments where passed an error was thrown as explained in issue #38.

Error was caused because the `[` binary does not use spaces on comparisons. Now fixed on all scripts using it.